### PR TITLE
Fix clear command to clear tutorials

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -160,7 +160,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setTutorials(List<Tutorial> tutorials) {
         requireNonNull(tutorials);
-
+        this.tutorials.clear();
         tutorials.stream().filter(Predicate.not(this::hasTutorial)).forEach(this::addTutorial);
     }
 


### PR DESCRIPTION
Fixes #130.
`setTutorial` method has been modified in AddressBook to clear tutorials before adding them.