### PR TITLE
Multiple Due Dates Allowed for Assignment Add Command Parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddAssignmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAssignmentCommandParser.java
@@ -34,6 +34,8 @@ public class AddAssignmentCommandParser implements Parser<AddAssignmentCommand> 
 
         var argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIAL_IDX, PREFIX_DATE);
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE);
+
         var idxList = argMultimap.getAllValues(PREFIX_TUTORIAL_IDX).stream().flatMap(idx -> {
             try {
                 return Stream.of(ParserUtil.parseIndex(idx));


### PR DESCRIPTION
Fixes #252. 

Command to add assignments should only specify ONE due date.